### PR TITLE
refactor: replacing fee subtracting mechanism in setup_refund

### DIFF
--- a/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
@@ -617,15 +617,7 @@ contract Token {
 
         // 2. Deduct the max fee from user's balance. The difference between max fee and the actual tx fee will
         // be refunded to the user in the `complete_refund(...)` function.
-        let change = subtract_balance(
-            &mut context,
-            storage,
-            user,
-            max_fee,
-            INITIAL_TRANSFER_CALL_MAX_NOTES,
-        );
-        // Emit the change note.
-        storage.balances.at(user).add(user, change).emit(encode_and_encrypt_note_unconstrained(
+        storage.balances.at(user).sub(user, max_fee).emit(encode_and_encrypt_note_unconstrained(
             &mut context,
             user,
             user,


### PR DESCRIPTION
```
cd noir-projects/noir-contracts/
./bootstrap.sh compile token_contract
./boostrap.sh test token_contract
```
Fails with:
```
[token_contract] Testing test::refunds::setup_refund_insufficient_funded_amount... FAIL

error: Test failed with the wrong message. 
Expected: Balance too low 
Got: Failed calling external resolver. ErrorObject { code: InvalidRequest, message: "Assertion failed: max fee not enough to cover tx fee 'max_fee >= tx_fee'", data: None }
```